### PR TITLE
Fixes for QR file field changes in 4chan X v1.10.3.

### DIFF
--- a/src/css/Colors.css
+++ b/src/css/Colors.css
@@ -274,6 +274,7 @@ a.quotelink.forwardlink, a.backlink.forwardlink {
 input:focus,
 textarea:focus,
 #qr-filename-container:focus,
+#qr-filename-container.focus,
 select:focus,
 .captcha-root:focus {
   border: 1px solid " + $SS.theme.linkColor.hex + " !important;

--- a/src/css/Fonts.css
+++ b/src/css/Fonts.css
@@ -58,6 +58,7 @@ body,
 #qr input.field,
 #qr textarea.field,
 #qr span.field,
+#qr-file-button,
 #qr input[type=submit],
 #qr select[data-name="thread"],
 #menu .entry,
@@ -96,11 +97,13 @@ a.qr-link {
 :root.info-on-hover .postContainer:hover .postNum {
   font-size:" + $SS.conf["Font Size"] + "px !important;
 }
+#qr-file-button,
 #qr input[type=submit],
 #qr label,
 .captcha-counter {
   font-size: " + (($SS.conf["Font Size"] < 11) ? 8 : 10) + "px !important;
 }
+#qr-file-button,
 #qr input[type="submit"],
 #qr label,
 .captcha-counter {

--- a/src/css/General.css
+++ b/src/css/General.css
@@ -140,6 +140,7 @@ div.post {
 }
 /* Checkboxes */
 input[type=checkbox],
+input[type=button],
 input[type=submit],
 .riceCheck {
   cursor: pointer;

--- a/src/css/Quickreply.css
+++ b/src/css/Quickreply.css
@@ -13,9 +13,22 @@
   position: relative;
   top: 3px;
 }
+#qr-filename-container .riceCheck,
+#qr-filename-container input[type=checkbox] {
+  margin: 0px 0px 1px!important;
+}
+#qr-file-button,
 #qr input[type='submit'] {
   height: 22px !important;
-  margin-top: 1px;
+  margin: 0 !important;
+}
+#qr-file-button,
+#qr-filename-container {
+  margin-right: 1px !important;
+}
+#qr-spoiler-label + input[type='submit'] {
+  /* ccd0 prior to v1.10.3 */
+  margin-top: 1px !important;
 }
 #qr select[data-name="thread"] {
   margin: 1px 0 1px 0;


### PR DESCRIPTION
This is my attempt at fixing the QR file field for the changes in 4chan X v1.10.3.  Fortunately not much seems to be really broken except for margins, and the new button that needs to be styled.  I've tried to write something that will work fine both with v1.10.2 (still the stable) and the new stuff, although ultimately it required some hacks like

    #qr-spoiler-label + input[type='submit'] {
      /* ccd0 prior to v1.10.3 */
      margin-top: 1px !important;
    }

which should probably be removed once v1.10.2 is gone.  I've used `#qr-file-button` rather than `#qr input[type=button]` in several places because my first attempt, which used `#qr input[type=button]`, broke the styling of the dump button in loadletter's fork.

Highlighting of the new filename field when focused is still broken both in vanilla 4chan X and Oneechan.  I may have to make some changes on the JS side to get that working.  I'll let you know when it is.